### PR TITLE
Fix bugs, memory leaks, and undefined behavior across codebase

### DIFF
--- a/src/rl_agent/src/Agent/Dyna.cc
+++ b/src/rl_agent/src/Agent/Dyna.cc
@@ -205,16 +205,19 @@ void Dyna::seedExp(std::vector<experience> &seeds){
     // add experience
     addExperience(e.reward,st,e.terminal);
 
-    // get max value of next state
-    const std::vector<float>::iterator max =
-      random_max_element(Q_next.begin(), Q_next.end());
-
     // Get q value for action taken
     const std::vector<float>::iterator a = Q_s.begin() + e.act;
     currentq = &*a;
 
     // Update value of action just executed
-    *currentq += alpha * (e.reward + gamma * (*max) - *currentq);
+    if (e.terminal){
+      *currentq += alpha * (e.reward - *currentq);
+    } else {
+      // get max value of next state
+      const std::vector<float>::iterator max =
+        random_max_element(Q_next.begin(), Q_next.end());
+      *currentq += alpha * (e.reward + gamma * (*max) - *currentq);
+    }
 
  
     /*
@@ -284,6 +287,7 @@ float Dyna::getValue(std::vector<float> state){
 
 void Dyna::savePolicy(const char* filename){
 
+  if (statespace.empty()) return;
   ofstream policyFile(filename, ios::out | ios::binary | ios::trunc);
 
   // first part, save the vector size

--- a/src/rl_agent/src/Agent/ModelBasedAgent.cc
+++ b/src/rl_agent/src/Agent/ModelBasedAgent.cc
@@ -494,7 +494,7 @@ void ModelBasedAgent::logValues(ofstream *of, int xmin, int xmax, int ymin, int 
   if (plannerType == PARALLEL_ET_UCT){
     ((ParallelETUCT*)planner)->logValues(of, xmin, xmax, ymin, ymax);
   }
-  if (plannerType == ET_UCT){
+  else if (plannerType == ET_UCT){
     ((ETUCT*)planner)->logValues(of, xmin, xmax, ymin, ymax);
   }
 

--- a/src/rl_agent/src/Agent/QLearner.cc
+++ b/src/rl_agent/src/Agent/QLearner.cc
@@ -155,16 +155,19 @@ void QLearner::seedExp(std::vector<experience> &seeds){
     std::vector<float> &Q_s = Q[canonicalize(e.s)];
     std::vector<float> &Q_next = Q[canonicalize(e.next)];
 
-    // get max value of next state
-    const std::vector<float>::iterator max =
-      random_max_element(Q_next.begin(), Q_next.end());
-
     // Get q value for action taken
     const std::vector<float>::iterator a = Q_s.begin() + e.act;
     currentq = &*a;
 
     // Update value of action just executed
-    *currentq += alpha * (e.reward + gamma * (*max) - *currentq);
+    if (e.terminal){
+      *currentq += alpha * (e.reward - *currentq);
+    } else {
+      // get max value of next state
+      const std::vector<float>::iterator max =
+        random_max_element(Q_next.begin(), Q_next.end());
+      *currentq += alpha * (e.reward + gamma * (*max) - *currentq);
+    }
 
 
     /*
@@ -234,6 +237,7 @@ float QLearner::getValue(std::vector<float> state){
 
 void QLearner::savePolicy(const char* filename){
 
+  if (statespace.empty()) return;
   ofstream policyFile(filename, ios::out | ios::binary | ios::trunc);
 
   // first part, save the vector size

--- a/src/rl_agent/src/Agent/Sarsa.cc
+++ b/src/rl_agent/src/Agent/Sarsa.cc
@@ -283,6 +283,7 @@ float Sarsa::getValue(std::vector<float> state){
 
 void Sarsa::savePolicy(const char* filename){
 
+  if (statespace.empty()) return;
   ofstream policyFile(filename, ios::out | ios::binary | ios::trunc);
 
   // first part, save the vector size

--- a/src/rl_agent/src/Agent/SavedPolicy.cc
+++ b/src/rl_agent/src/Agent/SavedPolicy.cc
@@ -119,6 +119,8 @@ void SavedPolicy::seedExp(std::vector<experience> &seeds){
 void SavedPolicy::loadPolicy(const char* filename){
 
   ifstream policyFile(filename, ios::in | ios::binary);
+  if (!policyFile.is_open())
+    return;
 
   // first part, save the vector size
   int fsize;

--- a/src/rl_agent/src/Models/C45Tree.cc
+++ b/src/rl_agent/src/Models/C45Tree.cc
@@ -467,10 +467,10 @@ void C45Tree::initTreeNode(tree_node* node){
 }
 
 void C45Tree::deleteTree(tree_node* node){
-  if (DTDEBUG) cout << "deleteTree, node=" << node->id << endl;
-
   if (node==NULL)
     return;
+
+  if (DTDEBUG) cout << "deleteTree, node=" << node->id << endl;
 
   totalnodes--;
 
@@ -909,7 +909,7 @@ float C45Tree::calcGainRatio(int dim, float val, bool type,
   Info = D[0] * leftInfo + D[1] * rightInfo;
   Gain = I - Info;
   SplitInfo = calcIofP((float*)&D, 2);
-  GainRatio = Gain / SplitInfo;
+  GainRatio = (SplitInfo > 0) ? (Gain / SplitInfo) : 0;
 
   if (DTDEBUG){
     cout << "LeftInfo: " << leftInfo
@@ -929,7 +929,8 @@ float C45Tree::calcIofP(float* P, int size){
   if (DTDEBUG) cout << "calcIofP, size=" << size << endl;
   float I = 0;
   for (int i = 0; i < size; i++){
-    I -= P[i] * log(P[i]);
+    if (P[i] > 0)
+      I -= P[i] * log(P[i]);
   }
   return I;
 }

--- a/src/rl_agent/src/Models/ExplorationModel.cc
+++ b/src/rl_agent/src/Models/ExplorationModel.cc
@@ -259,7 +259,6 @@ float ExplorationModel::getStateActionInfo(const std::vector<float> &state, int 
   if (exploreType == VISITS_CONF){
     if (conf < 0.5){
       float bonus = qmax;
-      retval->reward += bonus;
       if (MODEL_DEBUG){
         cout << "   State-Action conf< thresh or 0 visits: "
              << conf
@@ -278,7 +277,7 @@ float ExplorationModel::getStateActionInfo(const std::vector<float> &state, int 
   if (isnan(retval->reward))
     cout << "ERROR: Model returned reward of NaN" << endl;
 
-  return true;
+  return conf;
 
 }
 

--- a/src/rl_agent/src/Models/FactoredModel.cc
+++ b/src/rl_agent/src/Models/FactoredModel.cc
@@ -204,7 +204,6 @@ bool FactoredModel::updateWithExperiences(std::vector<experience> &instances){
       cout << "ERROR: size mismatch between input vector and # trees "
            << outputModels.size() << ", " << instances[0].next.size() << endl;
     return false;
-    exit(-1);
   }
 
   // separate these experience instances into classPairs
@@ -324,7 +323,6 @@ bool FactoredModel::updateWithExperience(experience &e){
     if (MODEL_DEBUG) cout << "ERROR: size mismatch between input vector and # trees "
                          << outputModels.size() << ", " << e.next.size() << endl;
     return false;
-    exit(-1);
   }
 
   std::vector<float> inputs(e.s.size() + nact);

--- a/src/rl_agent/src/Models/LinearSplitsTree.cc
+++ b/src/rl_agent/src/Models/LinearSplitsTree.cc
@@ -522,10 +522,10 @@ void LinearSplitsTree::initTreeNode(tree_node* node){
 
 /** delete current tree */
 void LinearSplitsTree::deleteTree(tree_node* node){
-  if (DTDEBUG) cout << "deleteTree, node=" << node->id << endl;
-
   if (node==NULL)
     return;
+
+  if (DTDEBUG) cout << "deleteTree, node=" << node->id << endl;
 
   totalnodes--;
 

--- a/src/rl_agent/src/Models/M5Tree.cc
+++ b/src/rl_agent/src/Models/M5Tree.cc
@@ -490,10 +490,10 @@ void M5Tree::initTreeNode(tree_node* node){
 }
 
 void M5Tree::deleteTree(tree_node* node){
-  if (DTDEBUG) cout << "deleteTree, node=" << node->id << endl;
-
   if (node==NULL)
     return;
+
+  if (DTDEBUG) cout << "deleteTree, node=" << node->id << endl;
 
   totalnodes--;
 

--- a/src/rl_agent/src/Models/MultipleClassifiers.cc
+++ b/src/rl_agent/src/Models/MultipleClassifiers.cc
@@ -121,8 +121,10 @@ bool MultipleClassifiers::trainInstances(std::vector<classPair> &instances){
     if (!didUpdate){
       int model = rng.uniformDiscrete(0,nModels-1);
       //cout << "none got instance, update model " << model << endl;
+      float origOutput = instances[j].out;
       if (addNoise) instances[j].out += rng.uniform(-0.2,0.2)*treeThresh;
       subsets[model].push_back(instances[j]);
+      if (addNoise) instances[j].out = origOutput;
     }
   } // instances loop
     
@@ -170,8 +172,10 @@ bool MultipleClassifiers::trainInstance(classPair &instance){
   // make sure some model got the transition
   if (!didUpdate){
     int model = rng.uniformDiscrete(0,nModels-1);
+    float origOutput = instance.out;
     if (addNoise) instance.out += rng.uniform(-0.2,0.2)*treeThresh;
     bool singleChange = models[model]->trainInstance(instance);
+    if (addNoise) instance.out = origOutput;
     changed = singleChange || changed;
   }
 
@@ -434,7 +438,7 @@ void MultipleClassifiers::initModels(){
       models[i] = new LinearSplitsTree(id + i*(1+nModels), mode, freq, 0, featPct, false, treeThresh, rng);
     }
     else if (modelType == STUMP){
-      models[i] = new Stump(id + 1*(1+nModels), mode, freq, 0, featPct, rng);
+      models[i] = new Stump(id + i*(1+nModels), mode, freq, 0, featPct, rng);
     }
     else if (modelType == ALLM5TYPES){
       // select an m5 type randomly.  so multivariate v single and allfeats v subtree feats

--- a/src/rl_agent/src/Models/MultipleModels.cc
+++ b/src/rl_agent/src/Models/MultipleModels.cc
@@ -24,7 +24,12 @@ MultipleModels::MultipleModels(int id, int nIn, int nOut, int modeltype, Random 
 
 }
 
-MultipleModels::~MultipleModels() {}
+MultipleModels::~MultipleModels() {
+  for (unsigned i = 0; i < models.size(); i++){
+    delete models[i];
+  }
+  models.clear();
+}
 
 
 

--- a/src/rl_agent/src/Models/Stump.cc
+++ b/src/rl_agent/src/Models/Stump.cc
@@ -598,7 +598,7 @@ float Stump::calcGainRatio(int dim, float val, int type,
   Info = D[0] * leftInfo + D[1] * rightInfo;
   Gain = I - Info;
   SplitInfo = calcIofP((float*)&D, 2);
-  GainRatio = Gain / SplitInfo;
+  GainRatio = (SplitInfo > 0) ? (Gain / SplitInfo) : 0;
 
   if (STDEBUG){
     cout << "LeftInfo: " << leftInfo
@@ -618,7 +618,8 @@ float Stump::calcIofP(float* P, int size){
   if (STDEBUG) cout << "calcIofP, size=" << size << endl;
   float I = 0;
   for (int i = 0; i < size; i++){
-    I -= P[i] * log(P[i]);
+    if (P[i] > 0)
+      I -= P[i] * log(P[i]);
   }
   return I;
 }

--- a/src/rl_agent/src/Planners/ETUCT.hh
+++ b/src/rl_agent/src/Planners/ETUCT.hh
@@ -234,7 +234,7 @@ private:
   const float MAX_TIME;
   const int MAX_DEPTH;
   const int modelType;
-  const std::vector<int> &statesPerDim;
+  const std::vector<int> statesPerDim;
   const bool trackActual;
   const int HISTORY_SIZE;
   const int HISTORY_FL_SIZE;

--- a/src/rl_agent/src/Planners/PO_ETUCT.hh
+++ b/src/rl_agent/src/Planners/PO_ETUCT.hh
@@ -224,7 +224,7 @@ private:
   const float MAX_TIME;
   const int MAX_DEPTH;
   const int modelType;
-  const std::vector<int> &statesPerDim;
+  const std::vector<int> statesPerDim;
   const bool trackActual;
   const int HISTORY_SIZE;
   const int HISTORY_FL_SIZE;

--- a/src/rl_agent/src/Planners/PO_ParallelETUCT.hh
+++ b/src/rl_agent/src/Planners/PO_ParallelETUCT.hh
@@ -315,7 +315,7 @@ private:
   const float MAX_TIME;
   const int MAX_DEPTH;
   const int modelType;
-  const std::vector<int> &statesPerDim;
+  const std::vector<int> statesPerDim;
   const bool trackActual;
   const int HISTORY_SIZE;
   const int HISTORY_FL_SIZE;

--- a/src/rl_agent/src/Planners/ParallelETUCT.hh
+++ b/src/rl_agent/src/Planners/ParallelETUCT.hh
@@ -312,7 +312,7 @@ private:
   const float MAX_TIME;
   const int MAX_DEPTH;
   const int modelType;
-  const std::vector<int> &statesPerDim;
+  const std::vector<int> statesPerDim;
   const bool trackActual;
   const int HISTORY_SIZE;
   const int HISTORY_FL_SIZE;

--- a/src/rl_agent/src/Planners/PolicyIteration.hh
+++ b/src/rl_agent/src/Planners/PolicyIteration.hh
@@ -146,7 +146,7 @@ private:
   const int MAX_LOOPS;
   const float MAX_TIME;
   const int modelType;
-  const std::vector<int> &statesPerDim;
+  const std::vector<int> statesPerDim;
 
 };
 

--- a/src/rl_agent/src/Planners/ValueIteration.cc
+++ b/src/rl_agent/src/Planners/ValueIteration.cc
@@ -283,7 +283,7 @@ void ValueIteration::createPolicy(){
   int statesUpdated = 0;
 
   // until convergence (always at least MIN_LOOPS)
-  while (maxError > MIN_ERROR){ // && nloops < MAX_LOOPS){
+  while (maxError > MIN_ERROR && nloops < MAX_LOOPS){
 
     //if ((getSeconds() - initTime) > MAX_TIME)
     // break;

--- a/src/rl_agent/src/agent.cpp
+++ b/src/rl_agent/src/agent.cpp
@@ -158,6 +158,7 @@ void processEnvDescription(const rl_msgs::RLEnvDescription::ConstPtr &envIn){
 
   // initialize the agent based on some info from the environment descriptor
   Random rng(seed+1);
+  delete agent;
   agent = NULL;
 
 
@@ -679,6 +680,8 @@ int main(int argc, char *argv[])
     if(filename != NULL) {
       agent->savePolicy(filename);
     }
+    delete agent;
+    agent = NULL;
   }
 
   return 0;

--- a/src/rl_common/include/rl_common/core.hh
+++ b/src/rl_common/include/rl_common/core.hh
@@ -57,6 +57,7 @@ const std::string modelNames[] = {
 #define SEPARATE       4 // sep model for planning, and forest for uncertainty
 
 const std::string comboNames[] = {
+  "Unknown",
   "Average",
   "Weighted Average",
   "Best",

--- a/src/rl_env/src/Env/LightWorld.cc
+++ b/src/rl_env/src/Env/LightWorld.cc
@@ -394,8 +394,8 @@ void LightWorld::getMinMaxFeatures(std::vector<float> *minFeat,
   minFeat->resize(s.size(), 0.0);
   maxFeat->resize(s.size(), MAX_SENSE);
 
-  // room id only goes to 2
-  (*maxFeat)[4] = 2;
+  // room id only goes to nrooms-1
+  (*maxFeat)[4] = nrooms - 1;
 
   // have_key and door_open are boolean
   (*maxFeat)[2] = 1;

--- a/src/rl_env/src/Env/MountainCar.cc
+++ b/src/rl_env/src/Env/MountainCar.cc
@@ -61,7 +61,7 @@ float MountainCar::apply(int action) {
 
   newVel = bound(newVel, -0.07, 0.07);
 
-  float newPos = pos + vel;
+  float newPos = pos + newVel;
   if (newPos < -1.2f && newVel < 0.0f)
     newVel = 0.0;
   newPos = bound(newPos, -1.2, 0.6);
@@ -120,9 +120,6 @@ void MountainCar::reset() {
     pos = 0;
     vel = 0;
   }
-
-  pos = rng.uniform(-1.2, 0.59);
-  vel = rng.uniform(-0.07, 0.07);
 
   if (delay > 0){
     posHistory.clear();

--- a/src/rl_env/src/Env/energyrooms.cc
+++ b/src/rl_env/src/Env/energyrooms.cc
@@ -114,7 +114,7 @@ float EnergyRooms::apply(int action) {
       energy = 10;
     if (ns == 3 && ew == 3)
       energy = 10;
-    if (ns == 7 && ew == 7)
+    if (ns == 3 && ew == 7)
       energy = 10;
   }
 

--- a/src/rl_env/src/Env/fourrooms.cc
+++ b/src/rl_env/src/Env/fourrooms.cc
@@ -59,7 +59,7 @@ FourRooms::FourRooms(Random &rand, bool stochastic, bool negReward,
   distW(unused[3]),
   rewardEW(unused[4]),
   rewardNS(unused[5]),
-  goalOption(goalOption)
+  goalOption(false)
 {
   reset();
 }

--- a/src/rl_env/src/env.cpp
+++ b/src/rl_env/src/env.cpp
@@ -394,10 +394,6 @@ int main(int argc, char *argv[])
   int qDepth = 1;
 
   // Set up Publishers
-  ros::init(argc, argv, "my_tf_broadcaster");
-  tf::Transform transform;
-
-  // Set up Publishers
   out_env_desc = node.advertise<rl_msgs::RLEnvDescription>("rl_env/rl_env_description",qDepth,true);
   out_env_sr = node.advertise<rl_msgs::RLStateReward>("rl_env/rl_state_reward",qDepth,false);
   out_seed = node.advertise<rl_msgs::RLEnvSeedExperience>("rl_env/rl_seed",20,false);
@@ -420,6 +416,7 @@ int main(int argc, char *argv[])
   //  ros::getGlobalCallbackQueue()->callAvailable(ros::WallDuration(0.1));
   //}
 
+  delete e;
   return 0;
 }
 


### PR DESCRIPTION
Models:
- Fix null pointer dereference in deleteTree() for C45Tree, M5Tree, LinearSplitsTree
- Fix ExplorationModel::getStateActionInfo() returning true instead of confidence
- Fix MultipleClassifiers Stump ID bug: 1*(1+nModels) -> i*(1+nModels)
- Fix log(0) NaN in calcIofP() and division by zero in calcGainRatio() for C45Tree, Stump
- Fix noise not restored on fallback path in MultipleClassifiers trainInstance/trainInstances
- Remove dead code after return in FactoredModel
- Fix memory leak in MultipleModels destructor (models not deleted)
- Remove redundant reward assignment in ExplorationModel VISITS_CONF

Agents:
- Add file-open check in SavedPolicy::loadPolicy()
- Add terminal state check in QLearner/Dyna seedExp()
- Add empty statespace guard in QLearner/Sarsa/Dyna savePolicy()
- Fix if/if to if/else-if for mutually exclusive planners in ModelBasedAgent

Planners:
- Fix dangling reference: store statesPerDim by value in ETUCT, PO_ETUCT,
  ParallelETUCT, PO_ParallelETUCT, PolicyIteration
- Re-enable MAX_LOOPS guard in ValueIteration to prevent infinite loop

Environments:
- Fix undefined behavior: fourrooms goalOption(goalOption) self-init -> goalOption(false)
- Fix duplicate fuel station in energyrooms: (ns==7,ew==7) -> (ns==3,ew==7)
- Fix MountainCar using old velocity for position update (vel -> newVel)
- Remove unconditional overwrite of deterministic reset in MountainCar
- Fix LightWorld maxFeat[4] hardcoded to 2, use nrooms-1

Infrastructure:
- Fix off-by-one in comboNames array (add "Unknown" at index 0)
- Remove duplicate ros::init and unused tf::Transform in env.cpp
- Fix memory leaks: delete agent on re-init and shutdown in agent.cpp
- Fix memory leak: delete environment on exit in env.cpp

https://claude.ai/code/session_012kvTKzT8iSvktpPAM3qWuK