### PR TITLE
Fix bugs, division-by-zero errors, memory leaks, and performance issues

### DIFF
--- a/src/rl_agent/src/Models/C45Tree.hh
+++ b/src/rl_agent/src/Models/C45Tree.hh
@@ -62,7 +62,7 @@ public:
     // split criterion
     int dim;
     float val;
-    bool type;
+    int type;
 
     // set of all outputs seen at this leaf/node
     std::map<float,int> outputs;

--- a/src/rl_agent/src/Models/ExplorationModel.cc
+++ b/src/rl_agent/src/Models/ExplorationModel.cc
@@ -137,7 +137,7 @@ float ExplorationModel::getStateActionInfo(const std::vector<float> &state, int 
       }
       retval->reward = qmax;
       retval->termProb = 1.0;
-      if (MODEL_DEBUG || MODEL_DEBUG)
+      if (MODEL_DEBUG)
         cout << "   State-Action Unknown in model, using qmax "
              << qmax << endl;
     }
@@ -325,7 +325,8 @@ float ExplorationModel::getFeatDistToVisitedSA(const std::vector<float> &s){
     for (unsigned j = 0; j < nfeats; j++){
       // distance based on magnitude of feature difference
       // normalize by feature range
-      count += fabs(s[j] - (*i)[j]) / featRange[j];
+      if (featRange[j] > 0)
+        count += fabs(s[j] - (*i)[j]) / featRange[j];
     }
     if (count < minDist) minDist = count;
 

--- a/src/rl_agent/src/Models/FactoredModel.cc
+++ b/src/rl_agent/src/Models/FactoredModel.cc
@@ -691,7 +691,7 @@ float FactoredModel::getStateActionInfo(const std::vector<float> &state, int act
 
 
 // gets the values/probs for index and adds them to the appropriate spot in the array
-void FactoredModel::addFactorProb(float* probs, std::vector<float>* next, std::vector<float> x, StateActionInfo* retval, int index, const std::vector< std::map<float,float> > &predictions, float* confSum){
+void FactoredModel::addFactorProb(float* probs, std::vector<float>* next, std::vector<float>& x, StateActionInfo* retval, int index, const std::vector< std::map<float,float> > &predictions, float* confSum){
 
   // get values, probs etc for this index
   std::map<float, float> outputPreds = predictions[index];
@@ -749,11 +749,13 @@ void FactoredModel::addFactorProb(float* probs, std::vector<float>* next, std::v
       }
 
       retval->transitionProbs[*next] += probs[index];
+      if (dep) x.pop_back();
       continue;
     }
 
     // next factors
     addFactorProb(probs, next, x, retval, index+1, predictions, confSum);
+    if (dep) x.pop_back();
 
   }
 }

--- a/src/rl_agent/src/Models/FactoredModel.hh
+++ b/src/rl_agent/src/Models/FactoredModel.hh
@@ -64,7 +64,7 @@ public:
   float getSingleSAInfo(const std::vector<float> &state, int act, StateActionInfo* retval);
 
   /** Combines predictions for each separate state feature into probabilities of the overall state vector */
-  void addFactorProb(float* probs, std::vector<float>* next, std::vector<float> x, StateActionInfo* retval, int index, const std::vector< std::map<float,float> > &predictions, float* confSum);
+  void addFactorProb(float* probs, std::vector<float>* next, std::vector<float>& x, StateActionInfo* retval, int index, const std::vector< std::map<float,float> > &predictions, float* confSum);
 
   /** Set some parameters of the subtrees */
   void setTreeParams(float margin, float forestPct, float minRatio);

--- a/src/rl_agent/src/Models/MultipleClassifiers.cc
+++ b/src/rl_agent/src/Models/MultipleClassifiers.cc
@@ -398,7 +398,7 @@ float MultipleClassifiers::variance(const std::vector<float> &input){
   }
 
   float mean = sum / (float)nModels;
-  float variance = (sumSqr - sum*mean) / (float)(nModels-1.0);
+  float variance = (nModels > 1) ? (sumSqr - sum*mean) / (float)(nModels-1.0) : 0.0;
 
   if (CONF_DEBUG) cout << "variance of predictions is " << variance << endl;
 

--- a/src/rl_agent/src/Models/RMaxModel.cc
+++ b/src/rl_agent/src/Models/RMaxModel.cc
@@ -146,7 +146,7 @@ float RMaxModel::getStateActionInfo(const std::vector<float> &state, int act, St
     int count = ((*it).second)[act];
 
     // add to transition map
-    if (count > 0.0){
+    if (count > 0 && info->visits[act] > info->terminations[act]){
       retval->transitionProbs[next] = (float)count / (float)(info->visits[act] - info->terminations[act]);
       if (RMAX_DEBUG) cout << "Outcome " << &next << " has prob " << retval->transitionProbs[next]
 			   << " from count of " << count << " on " 

--- a/src/rl_agent/src/Models/Stump.cc
+++ b/src/rl_agent/src/Models/Stump.cc
@@ -322,6 +322,7 @@ int Stump::findMatching(const std::vector<stump_experience*> &instances, int dim
 void Stump::initStump(){
   if (STDEBUG) cout << "initStump()" << endl;
 
+  nnodes = 0;
   dim = -1;
   val = -1;
   type = -1;
@@ -853,7 +854,7 @@ void Stump::printStump(){
 */
 
 // output a map of outcomes and their probabilities for this leaf node
-void Stump::outputProbabilities(std::multiset<float> outputs, std::map<float, float>* retval){
+void Stump::outputProbabilities(const std::multiset<float>& outputs, std::map<float, float>* retval){
   if (STDEBUG) cout << " Calculating output probs" << endl;
 
   // go through all possible output values

--- a/src/rl_agent/src/Models/Stump.hh
+++ b/src/rl_agent/src/Models/Stump.hh
@@ -60,7 +60,7 @@ public:
 		     int *nties, float *bestGainRatio, int *bestDim, 
 		     float *bestVal, int *bestType);
   //std::vector<float> calcChiSquare(std::vector<stump_experience*> instances);
-  void outputProbabilities(std::multiset<float> outputs, std::map<float, float>* retval);
+  void outputProbabilities(const std::multiset<float>& outputs, std::map<float, float>* retval);
   int findMatching(const std::vector<stump_experience*> &instances, int dim, 
 		   int val, int minConf);
 

--- a/src/rl_agent/src/Planners/PO_ParallelETUCT.cc
+++ b/src/rl_agent/src/Planners/PO_ParallelETUCT.cc
@@ -141,11 +141,19 @@ PO_ParallelETUCT::~PO_ParallelETUCT() {
   statespace.clear();
   statedata.clear();
 
-  pthread_mutex_unlock(&plan_state_mutex);
-  pthread_mutex_unlock(&statespace_mutex);
-  pthread_mutex_unlock(&model_mutex);
-  pthread_mutex_unlock(&list_mutex);
   pthread_mutex_unlock(&history_mutex);
+  pthread_mutex_unlock(&list_mutex);
+  pthread_mutex_unlock(&model_mutex);
+  pthread_mutex_unlock(&statespace_mutex);
+  pthread_mutex_unlock(&plan_state_mutex);
+
+  pthread_mutex_destroy(&history_mutex);
+  pthread_mutex_destroy(&list_mutex);
+  pthread_mutex_destroy(&model_mutex);
+  pthread_mutex_destroy(&statespace_mutex);
+  pthread_mutex_destroy(&plan_state_mutex);
+  pthread_mutex_destroy(&nactions_mutex);
+  pthread_mutex_destroy(&update_mutex);
 
 }
 
@@ -781,6 +789,8 @@ void PO_ParallelETUCT::deleteInfo(state_info* info){
   pthread_mutex_lock(&info->statemodel_mutex);
   delete [] info->model;
   pthread_mutex_unlock(&info->statemodel_mutex);
+  pthread_mutex_destroy(&info->statemodel_mutex);
+  pthread_mutex_destroy(&info->stateinfo_mutex);
 
 }
 

--- a/src/rl_agent/src/Planners/ParallelETUCT.cc
+++ b/src/rl_agent/src/Planners/ParallelETUCT.cc
@@ -142,10 +142,18 @@ ParallelETUCT::~ParallelETUCT() {
   statespace.clear();
   statedata.clear();
 
-  pthread_mutex_unlock(&plan_state_mutex);
-  pthread_mutex_unlock(&statespace_mutex);
-  pthread_mutex_unlock(&model_mutex);
   pthread_mutex_unlock(&list_mutex);
+  pthread_mutex_unlock(&model_mutex);
+  pthread_mutex_unlock(&statespace_mutex);
+  pthread_mutex_unlock(&plan_state_mutex);
+
+  pthread_mutex_destroy(&list_mutex);
+  pthread_mutex_destroy(&model_mutex);
+  pthread_mutex_destroy(&statespace_mutex);
+  pthread_mutex_destroy(&plan_state_mutex);
+  pthread_mutex_destroy(&nactions_mutex);
+  pthread_mutex_destroy(&history_mutex);
+  pthread_mutex_destroy(&update_mutex);
 
 }
 
@@ -759,6 +767,8 @@ void ParallelETUCT::printStates(){
 void ParallelETUCT::deleteInfo(state_info* info){
 
   delete [] info->historyModel;
+  pthread_mutex_destroy(&info->statemodel_mutex);
+  pthread_mutex_destroy(&info->stateinfo_mutex);
 
 }
 

--- a/src/rl_agent/src/Planners/PolicyIteration.cc
+++ b/src/rl_agent/src/Planners/PolicyIteration.cc
@@ -548,7 +548,7 @@ float PolicyIteration::getActionValue(state_t s, state_info* info,
 	 = modelInfo->transitionProbs.begin();
        outIt != modelInfo->transitionProbs.end(); outIt++){
     
-    std::vector<float> nextstate = (*outIt).first;  
+    const std::vector<float>& nextstate = (*outIt).first;  
     
     if (POLICYDEBUG){
       cout << "  Next state was: ";

--- a/src/rl_agent/src/Planners/PrioritizedSweeping.cc
+++ b/src/rl_agent/src/Planners/PrioritizedSweeping.cc
@@ -313,7 +313,7 @@ void PrioritizedSweeping::printStates(){
              = info->modelInfo[act].transitionProbs.begin();
            outIt != info->modelInfo[act].transitionProbs.end(); outIt++){
 
-        std::vector<float> nextstate = (*outIt).first;
+        const std::vector<float>& nextstate = (*outIt).first;
         float prob = (*outIt).second;
 
         cout << "   State ";
@@ -595,7 +595,7 @@ float PrioritizedSweeping::updateQValues(const std::vector<float> &state, int ac
          = modelInfo->transitionProbs.begin();
        outIt != modelInfo->transitionProbs.end(); outIt++){
 
-    std::vector<float> nextstate = (*outIt).first;
+    const std::vector<float>& nextstate = (*outIt).first;
 
     if (POLICYDEBUG){
       cout << "  Next state was: ";
@@ -743,7 +743,7 @@ void PrioritizedSweeping::updateStateActionFromModel(const std::vector<float> &s
          = info->modelInfo[j].transitionProbs.begin();
        outIt != info->modelInfo[j].transitionProbs.end(); outIt++){
 
-    std::vector<float> nextstate = (*outIt).first;
+    const std::vector<float>& nextstate = (*outIt).first;
     state_t next = canonicalize(nextstate);
     state_info* nextinfo = &(statedata[next]);
     //float prob = (*outIt).second;

--- a/src/rl_agent/src/Planners/ValueIteration.cc
+++ b/src/rl_agent/src/Planners/ValueIteration.cc
@@ -353,7 +353,7 @@ void ValueIteration::createPolicy(){
                = modelInfo->transitionProbs.begin();
              outIt != modelInfo->transitionProbs.end(); outIt++){
 
-          std::vector<float> nextstate = (*outIt).first;
+          const std::vector<float>& nextstate = (*outIt).first;
 
           if (POLICYDEBUG){
             cout << "  Next state was: ";

--- a/src/rl_common/include/rl_common/ExperienceFile.hh
+++ b/src/rl_common/include/rl_common/ExperienceFile.hh
@@ -33,7 +33,7 @@ public:
     vectorFile.write((char*)&nfeats, sizeof(int));
   }
 
-  void saveExperience(experience e){
+  void saveExperience(const experience& e){
     if (!vectorFile.is_open())
       return;
 
@@ -55,7 +55,7 @@ public:
     //printExperience(e);
   }
 
-  void printExperience(experience e){
+  void printExperience(const experience& e){
 
     cout << "State s: ";
     for(unsigned i = 0; i < e.s.size(); i++){

--- a/src/rl_common/include/rl_common/Random.h
+++ b/src/rl_common/include/rl_common/Random.h
@@ -202,7 +202,7 @@ public:
 
   ~Random( void )   // default destructor
    {
-
+      pthread_mutex_destroy(&random_mutex);
    }
    
    Random( const Random& r )   // copy constructor (copies current state)

--- a/src/rl_env/src/Env/FuelRooms.cc
+++ b/src/rl_env/src/Env/FuelRooms.cc
@@ -96,9 +96,6 @@ float FuelRooms::apply(int action) {
       ew--;
   
   return r;
-  
-  std::cerr << "Unreachable point reached in FuelRooms::apply!!!\n";
-  return 0; // unreachable, I hope
 }
 
 

--- a/src/rl_env/src/env.cpp
+++ b/src/rl_env/src/env.cpp
@@ -265,7 +265,7 @@ int main(int argc, char *argv[])
   }
 
   // now parse other options
-  char ch;
+  int ch;
   const char* optflags = "ds:";
   int option_index = 0;
   static struct option long_options[] = {


### PR DESCRIPTION
Bug fixes:
- ExplorationModel: fix copy-paste bug (MODEL_DEBUG || MODEL_DEBUG)
- ExplorationModel: guard against division by zero in getFeatDistToVisitedSA
  when feature range is zero
- RMaxModel: guard against division by zero in transition probability
  calculation when all visits are terminal
- MultipleClassifiers: guard against division by zero in variance()
  when nModels==1
- FactoredModel: fix addFactorProb accumulating push_back values across
  loop iterations in dependent mode (missing pop_back)
- C45Tree: change tree_node::type from bool to int so -1 sentinel value
  works correctly (was silently converted to true)
- env.cpp: change getopt return variable from char to int to prevent
  potential infinite loop on platforms with unsigned char

Memory/resource leaks:
- Random: add pthread_mutex_destroy in destructor
- ParallelETUCT: destroy all 7 mutexes and per-state mutexes in destructor,
  fix mutex unlock order to reverse of lock order
- PO_ParallelETUCT: same mutex destroy and unlock order fixes

Performance improvements:
- Stump: pass multiset by const reference in outputProbabilities
- FactoredModel: pass vector by reference in addFactorProb recursion
- ExperienceFile: pass experience by const reference in save/print
- ValueIteration, PolicyIteration, PrioritizedSweeping: use const reference
  for next-state vectors in policy computation loops

Other:
- Stump: initialize nnodes member variable in initStump()
- FuelRooms: remove dead code after return statement

https://claude.ai/code/session_01Y24NkrFQ2JA6XCGyo5PjDt